### PR TITLE
Add cancel payment order flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,23 @@
 *** Changelog ***
 
+= 1.4.0 = 2023-08-18 =
+* Added - Support for bypass payment page for WooCommerce Blocks checkout for FPX B2C and FPX B2B1
+* Added - Support for bypass payment page for legacy WooCommerce checkout for cards.
+* Added - Default payment method whitelist for easier configuration.
+* Added - Item charge for adding additional fee.
+* Added - New icon.
+* Added - Now bypass payment page for FPX will be based on banks availability.
+
+= 1.3.9 = 2023-07-21 =
+* Added   - Support for $0 initial checkout.
+* Changed - Set redirect parameter to direct_post_url for Visa/Mastercard payment method
+* Fixed   - Error after payment for admin after making payment
+* Fixed   - Missing client if the order created through dashboard
+
+= 1.3.8 = 2023-05-27 =
+* Added - State information for address in billing and shipping
+* Fixed - Zip code billing should taken from billing
+
 = 1.3.7 = 2023-05-24 =
 * Added - Quantity in CHIP Purchase invoice.
 

--- a/chip-for-woocommerce.php
+++ b/chip-for-woocommerce.php
@@ -4,12 +4,12 @@
  * Plugin Name: CHIP for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/chip-for-woocommerce/
  * Description: CHIP - Digital Finance Platform
- * Version: 1.4.4
+ * Version: 1.4.5
  * Author: Chip In Sdn Bhd
  * Author URI: https://www.chip-in.asia
  *
  * WC requires at least: 5.1
- * WC tested up to: 8.1
+ * WC tested up to: 8.2
  *
  * Copyright: © 2023 CHIP
  * License: GNU General Public License v3.0
@@ -53,7 +53,7 @@ class Chip_Woocommerce {
   }
 
   public function define() {
-    define( 'WC_CHIP_MODULE_VERSION', 'v1.4.4' );
+    define( 'WC_CHIP_MODULE_VERSION', 'v1.4.5' );
     define( 'WC_CHIP_FILE', __FILE__ );
     define( 'WC_CHIP_BASENAME', plugin_basename( WC_CHIP_FILE ) );
     define( 'WC_CHIP_URL', plugin_dir_url( WC_CHIP_FILE ) );

--- a/chip-for-woocommerce.php
+++ b/chip-for-woocommerce.php
@@ -7,6 +7,8 @@
  * Version: 1.4.5
  * Author: Chip In Sdn Bhd
  * Author URI: https://www.chip-in.asia
+ * Requires PHP: 7.1
+ * Requires at least: 4.7
  *
  * WC requires at least: 5.1
  * WC tested up to: 8.2

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: chipasia, wanzulnet
 Tags: chip
 Requires at least: 4.7
-Tested up to: 6.3
-Stable tag: 1.4.4
+Tested up to: 6.4
+Stable tag: 1.4.5
 Requires PHP: 7.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -35,6 +35,9 @@ The plugins do includes support for WooCommerce Subscription products.
 
 == Changelog ==
 
+= 1.4.5 = 2023-11-08 =
+* Added - Introduce alternative payment journey for unpaid order
+
 = 1.4.4 = 2023-10-26 =
 * Added - Maestro logo option for international payment method support
 * Fixed - Syntax error on preauthorize action when X Signature is failed
@@ -55,24 +58,6 @@ The plugins do includes support for WooCommerce Subscription products.
 * Fixed - Performance improvement for FPX bypass page status check.
 * Fixed - Ensure bypass chip payment page works without maestro option.
 * Fixed - Fix checkout issue with CheckoutWC
-
-= 1.4.0 = 2023-08-18 =
-* Added - Support for bypass payment page for WooCommerce Blocks checkout for FPX B2C and FPX B2B1
-* Added - Support for bypass payment page for legacy WooCommerce checkout for cards.
-* Added - Default payment method whitelist for easier configuration.
-* Added - Item charge for adding additional fee.
-* Added - New icon.
-* Added - Now bypass payment page for FPX will be based on banks availability.
-
-= 1.3.9 = 2023-07-21 =
-* Added   - Support for $0 initial checkout.
-* Changed - Set redirect parameter to direct_post_url for Visa/Mastercard payment method
-* Fixed   - Error after payment for admin after making payment
-* Fixed   - Missing client if the order created through dashboard
-
-= 1.3.8 = 2023-05-27 =
-* Added - State information for address in billing and shipping
-* Fixed - Zip code billing should taken from billing
 
 == Installation ==
 


### PR DESCRIPTION
## What does this change?
This add new option for merchant who needs to have specific unpaid order path. Instead of redirecting to `get_return_url`, the merchant now have an option to set `cancel_order_url`.

## Asana / Jira / Trello task link
[Asana](https://app.asana.com/0/1203417845528369/1205904813493366/f)

## How to test

Tick the checkbox for **Cancel Order Flow**, make an order and cancel the purchase. The customer should get **order was cancelled** message.

<img width="1380" alt="Screenshot 2023-11-08 at 2 10 37 PM" src="https://github.com/CHIPAsia/chip-for-woocommerce/assets/19372567/9f0052cb-ae8b-43cd-90ae-8ffbf7f1841d">

Without the option checked, cancelling a purchase will show **Unfortunately your order cannot be processed** message.

<img width="1382" alt="Screenshot 2023-11-08 at 2 10 12 PM" src="https://github.com/CHIPAsia/chip-for-woocommerce/assets/19372567/0c08bd43-184d-4863-9e8e-698298d9c175">

## Images

<img width="1376" alt="Screenshot 2023-11-08 at 2 12 38 PM" src="https://github.com/CHIPAsia/chip-for-woocommerce/assets/19372567/911f244c-131d-4d7b-b8ed-44df73004ab3">

## PR Checklist:

-   [ ] Unit test provided?
-   [ ] All unit tests passed?
-   [ ] Deployed and tested in staging?
-   [ ] Project Management Solution (Asana / Jira / Trello) task link provided?
