### PR TITLE
Fix issue with img class name on classic checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.6.3 2024-06-29 =
+* Fixed - Issue with metabox when no collection available
+
 = 1.6.2 2024-06-20 =
 * Changed - Uncheck Purchase Send Receipt by Default
 

--- a/chip-for-woocommerce.php
+++ b/chip-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: CHIP for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/chip-for-woocommerce/
  * Description: CHIP - Digital Finance Platform
- * Version: 1.6.3
+ * Version: 1.6.4
  * Author: Chip In Sdn Bhd
  * Author URI: https://www.chip-in.asia
  * Requires PHP: 7.1
@@ -56,7 +56,7 @@ class Chip_Woocommerce {
   }
 
   public function define() {
-    define( 'WC_CHIP_MODULE_VERSION', 'v1.6.3' );
+    define( 'WC_CHIP_MODULE_VERSION', 'v1.6.4' );
     define( 'WC_CHIP_FILE', __FILE__ );
     define( 'WC_CHIP_BASENAME', plugin_basename( WC_CHIP_FILE ) );
     define( 'WC_CHIP_URL', plugin_dir_url( WC_CHIP_FILE ) );

--- a/includes/class-wc-gateway-chip.php
+++ b/includes/class-wc-gateway-chip.php
@@ -203,7 +203,7 @@ class WC_Gateway_Chip extends WC_Payment_Gateway
 
     $style = apply_filters( 'wc_' . $this->id . '_get_icon_style', $style, $this );
     
-    $icon = '<img class="chip-for-woocommerce-" ' . $this->id . ' src="' . WC_HTTPS::force_https_url( $this->icon ) . '" alt="' . esc_attr( $this->get_title() ) . '" style="' . esc_attr( $style ) . '" />';
+    $icon = '<img class="chip-for-woocommerce-' . $this->id . '" src="' . WC_HTTPS::force_https_url( $this->icon ) . '" alt="' . esc_attr( $this->get_title() ) . '" style="' . esc_attr( $style ) . '" />';
     return apply_filters( 'woocommerce_gateway_icon', $icon, $this->id );
   }
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: chipasia, wanzulnet
 Tags: chip
 Requires at least: 4.7
-Tested up to: 6.5
-Stable tag: 1.6.3
+Tested up to: 6.6
+Stable tag: 1.6.4
 Requires PHP: 7.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -34,8 +34,8 @@ The plugins do includes support for WooCommerce Subscription products.
 
 == Changelog ==
 
-= 1.6.3 2024-06-29 =
-* Fixed - Issue with metabox when no collection available
+= 1.6.4 2024-07-17 =
+* Fixed - Fix issue image class name for classic checkout
 
 [See changelog for all versions](https://raw.githubusercontent.com/CHIPAsia/chip-for-woocommerce/main/changelog.txt).
 


### PR DESCRIPTION
## What does this change?
Fix issue with class name on classic checkout

## Asana / Jira / Trello task link

## How to test
- Image on classic checkout should have correct class name

## Images

<img width="1468" alt="Screenshot 2024-07-17 at 11 39 19 AM" src="https://github.com/user-attachments/assets/11df3638-3336-4dd5-9d8c-4a05550a9b23">


## PR Checklist:

-   [ ] Unit test provided?
-   [ ] All unit tests passed?
-   [ ] Deployed and tested in staging?
-   [ ] Project Management Solution (Asana / Jira / Trello) task link provided?
