### PR TITLE
Remove send receipt option

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 == Changelog ==
 
+= 1.7.0 2025-07-16 =
+* Removed - Send receipt option from admin settings
+* Changed - Hardcoded send_receipt parameter to false for all payment methods
+* Removed - Unused purchase_sr variable
+
 = 1.6.9 2025-06-28 =
 * Fixed - FPX dropdown banks not showing some banks
 

--- a/chip-for-woocommerce.php
+++ b/chip-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: CHIP for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/chip-for-woocommerce/
  * Description: CHIP - Digital Finance Platform
- * Version: 1.6.9
+ * Version: 1.7.0
  * Author: Chip In Sdn Bhd
  * Author URI: https://chip-in.asia
  * Requires PHP: 7.4
@@ -58,7 +58,7 @@ class Chip_Woocommerce {
 	}
 
 	public function define() {
-		define( 'WC_CHIP_MODULE_VERSION', 'v1.6.9' );
+		define( 'WC_CHIP_MODULE_VERSION', 'v1.7.0' );
 		define( 'WC_CHIP_FILE', __FILE__ );
 		define( 'WC_CHIP_BASENAME', plugin_basename( WC_CHIP_FILE ) );
 		define( 'WC_CHIP_URL', plugin_dir_url( WC_CHIP_FILE ) );

--- a/includes/class-wc-gateway-chip.php
+++ b/includes/class-wc-gateway-chip.php
@@ -480,7 +480,7 @@ class WC_Gateway_Chip extends WC_Payment_Gateway {
 		$this->form_fields['miscellaneous'] = array(
 			'title' => __( 'Miscellaneous', 'chip-for-woocommerce' ),
 			'type' => 'title',
-			'description' => __( 'Options to set display logo, due strict, send receipt, time zone, tokenization and payment method whitelist.', 'chip-for-woocommerce' ),
+			'description' => __( 'Options to set display logo, due strict, time zone, tokenization and payment method whitelist.', 'chip-for-woocommerce' ),
 		);
 
 		$this->form_fields['display_logo'] = array(

--- a/includes/class-wc-gateway-chip.php
+++ b/includes/class-wc-gateway-chip.php
@@ -6,7 +6,7 @@ class WC_Gateway_Chip extends WC_Payment_Gateway {
 	protected $brand_id;
 	protected $due_strict;
 	protected $due_str_t;
-	protected $purchase_sr;
+
 	protected $purchase_tz;
 	protected $update_clie;
 	protected $system_url_;
@@ -59,7 +59,7 @@ class WC_Gateway_Chip extends WC_Payment_Gateway {
 		$this->brand_id = $this->get_option( 'brand_id' );
 		$this->due_strict = $this->get_option( 'due_strict', 'yes' );
 		$this->due_str_t = $this->get_option( 'due_strict_timing', 60 );
-		$this->purchase_sr = $this->get_option( 'purchase_send_receipt', 'yes' );
+
 		$this->purchase_tz = $this->get_option( 'purchase_time_zone', 'Asia/Kuala_Lumpur' );
 		$this->update_clie = $this->get_option( 'update_client_information' );
 		$this->system_url_ = $this->get_option( 'system_url_scheme', 'https' );
@@ -523,12 +523,7 @@ class WC_Gateway_Chip extends WC_Payment_Gateway {
 			'default' => get_option( 'woocommerce_hold_stock_minutes', '60' ),
 		);
 
-		$this->form_fields['purchase_send_receipt'] = array(
-			'title' => __( 'Purchase Send Receipt', 'chip-for-woocommerce' ),
-			'type' => 'checkbox',
-			'description' => __( 'Tick to ask CHIP to send a receipt to the customer upon successful payment. If enabled, CHIP will send a purchase receipt once payment is completed. WooCommerce will always sends order processing and completed notifications to the customer.', 'chip-for-woocommerce' ),
-			'default' => 'no',
-		);
+
 
 		$this->form_fields['purchase_time_zone'] = array(
 			'title' => __( 'Purchase Time Zone', 'chip-for-woocommerce' ),
@@ -881,7 +876,7 @@ class WC_Gateway_Chip extends WC_Payment_Gateway {
 			'failure_redirect' => $callback_url,
 			'cancel_redirect' => $callback_url,
 			'force_recurring' => $this->force_token == 'yes',
-			'send_receipt' => $this->purchase_sr == 'yes',
+			'send_receipt' => false,
 			'creator_agent' => 'WooCommerce: ' . WC_CHIP_MODULE_VERSION,
 			'reference' => $order->get_id(),
 			'platform' => 'woocommerce',
@@ -1272,7 +1267,7 @@ class WC_Gateway_Chip extends WC_Payment_Gateway {
 
 		$params = [
 			'success_callback' => $callback_url,
-			'send_receipt' => $this->purchase_sr == 'yes',
+			'send_receipt' => false,
 			'creator_agent' => 'WooCommerce: ' . WC_CHIP_MODULE_VERSION,
 			'reference' => $renewal_order_id,
 			'platform' => 'woocommerce_subscriptions',
@@ -2242,7 +2237,7 @@ class WC_Gateway_Chip extends WC_Payment_Gateway {
 
 		$params = [
 			'success_callback' => $callback_url,
-			'send_receipt' => $this->purchase_sr == 'yes',
+			'send_receipt' => false,
 			'creator_agent' => 'WooCommerce: ' . WC_CHIP_MODULE_VERSION,
 			'reference' => $order->get_id(),
 			'platform' => 'woocommerce',

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: chipasia, wanzulnet, awisqirani, amirulazreen
 Tags: chip
 Requires at least: 6.3
 Tested up to: 6.8
-Stable tag: 1.6.9
+Stable tag: 1.7.0
 Requires PHP: 7.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -34,8 +34,11 @@ The plugins do includes support for WooCommerce Subscription products.
 
 == Changelog ==
 
-= 1.6.9 2025-06-28 =
-* Fixed - FPX dropdown banks not showing some banks
+= 1.7.0 2025-07-16 =
+* Removed - Send receipt option from admin settings
+* Changed - Hardcoded send_receipt parameter to false for all payment methods
+* Removed - Unused purchase_sr variable
+
 
 [See changelog for all versions](https://raw.githubusercontent.com/CHIPAsia/chip-for-woocommerce/main/changelog.txt).
 


### PR DESCRIPTION
## What does this change?
This to remove send receipt option since the option is now available through CHIP Merchant Portal.

## Asana / Jira / Trello task link
[Asana](https://app.asana.com/1/1203390264907019/project/1203417845528369/task/1210807021750056?focus=true)

## How to test
Attempt to make payment and check the parameter `send_receipt` in the purchase object. The value must be `false`.

## Images

## PR Checklist:

-   [ ] Unit test provided?
-   [ ] All unit tests passed?
-   [ ] Deployed and tested in staging?
-   [ ] Project Management Solution (Asana / Jira / Trello) task link provided?
