### PR TITLE
Gracefully handle error when logger is unavailable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
 == Changelog ==
 
 = 1.8.0 2025-07-18 =
-* Changed - Updated minimum WooCommerce requirement to 9.3.0
 * Changed - Enhanced logger implementation with multiple log levels (info, error, debug)
 * Changed - Improved error handling in logger with fallback to WordPress error_log
 * Changed - Bumped WooCommerce tested version to 10.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 == Changelog ==
 
+= 1.8.0 2025-07-18 =
+* Changed - Updated minimum WooCommerce requirement to 9.3.0
+* Changed - Enhanced logger implementation with multiple log levels (info, error, debug)
+* Changed - Improved error handling in logger with fallback to WordPress error_log
+* Changed - Bumped WooCommerce tested version to 10.0
+
 = 1.7.0 2025-07-16 =
 * Removed - Send receipt option from admin settings
 * Changed - Hardcoded send_receipt parameter to false for all payment methods

--- a/chip-for-woocommerce.php
+++ b/chip-for-woocommerce.php
@@ -4,14 +4,14 @@
  * Plugin Name: CHIP for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/chip-for-woocommerce/
  * Description: CHIP - Digital Finance Platform
- * Version: 1.7.0
+ * Version: 1.8.0
  * Author: Chip In Sdn Bhd
  * Author URI: https://chip-in.asia
  * Requires PHP: 7.4
  * Requires at least: 6.3
  *
- * WC requires at least: 5.1
- * WC tested up to: 9.9
+ * WC requires at least: 9.3.0
+ * WC tested up to: 10.0
  * Requires Plugins: woocommerce
  *
  * Copyright: © 2025 CHIP
@@ -58,7 +58,7 @@ class Chip_Woocommerce {
 	}
 
 	public function define() {
-		define( 'WC_CHIP_MODULE_VERSION', 'v1.7.0' );
+		define( 'WC_CHIP_MODULE_VERSION', 'v1.8.0' );
 		define( 'WC_CHIP_FILE', __FILE__ );
 		define( 'WC_CHIP_BASENAME', plugin_basename( WC_CHIP_FILE ) );
 		define( 'WC_CHIP_URL', plugin_dir_url( WC_CHIP_FILE ) );
@@ -143,6 +143,20 @@ class Chip_Woocommerce {
 
 	public static function load() {
 		if ( ! class_exists( 'WooCommerce' ) or ! class_exists( 'WC_Payment_Gateway' ) ) {
+			return;
+		}
+
+		// Check if WooCommerce version is at least 9.3.0
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '9.3.0', '<' ) ) {
+			add_action( 'admin_notices', function() {
+				echo '<div class="notice notice-error"><p>';
+				printf(
+					__( 'CHIP for WooCommerce requires WooCommerce 9.3.0 or higher. You are currently running WooCommerce %s. Please <a href="%s">update WooCommerce</a> to continue using CHIP for WooCommerce.', 'chip-for-woocommerce' ),
+					WC_VERSION,
+					admin_url( 'plugins.php' )
+				);
+				echo '</p></div>';
+			} );
 			return;
 		}
 

--- a/chip-for-woocommerce.php
+++ b/chip-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Requires PHP: 7.4
  * Requires at least: 6.3
  *
- * WC requires at least: 9.3.0
+ * WC requires at least: 5.1
  * WC tested up to: 10.0
  * Requires Plugins: woocommerce
  *
@@ -143,20 +143,6 @@ class Chip_Woocommerce {
 
 	public static function load() {
 		if ( ! class_exists( 'WooCommerce' ) or ! class_exists( 'WC_Payment_Gateway' ) ) {
-			return;
-		}
-
-		// Check if WooCommerce version is at least 9.3.0
-		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '9.3.0', '<' ) ) {
-			add_action( 'admin_notices', function() {
-				echo '<div class="notice notice-error"><p>';
-				printf(
-					__( 'CHIP for WooCommerce requires WooCommerce 9.3.0 or higher. You are currently running WooCommerce %s. Please <a href="%s">update WooCommerce</a> to continue using CHIP for WooCommerce.', 'chip-for-woocommerce' ),
-					WC_VERSION,
-					admin_url( 'plugins.php' )
-				);
-				echo '</p></div>';
-			} );
 			return;
 		}
 

--- a/includes/class-wc-api-fpx.php
+++ b/includes/class-wc-api-fpx.php
@@ -92,12 +92,16 @@ class Chip_Woocommerce_API_FPX {
 	}
 
 	public function log_info( $text ) {
-		if ( $this->debug ) {
+		if ( $this->debug === 'yes' ) {
 			$this->logger->log( "INFO: {$text};" );
 		}
 	}
 
 	public function log_error( $error_text, $error_data = null ) {
+		if ( $this->debug !== 'yes' ) {
+			return;
+		}
+
 		$error_text = "ERROR: {$error_text};";
 
 		if ( $error_data ) {

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -205,12 +205,16 @@ class Chip_Woocommerce_API {
 	}
 
 	public function log_info( $text ) {
-		if ( $this->debug ) {
+		if ( $this->debug === 'yes' ) {
 			$this->logger->log( "INFO: {$text};" );
 		}
 	}
 
 	public function log_error( $error_text, $error_data = null ) {
+		if ( $this->debug !== 'yes' ) {
+			return;
+		}
+
 		$error_text = "ERROR: {$error_text};";
 
 		if ( $error_data ) {

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -2,12 +2,43 @@
 
 class Chip_Woocommerce_Logger {
 	private $logger;
+	private $context;
 
 	public function __construct() {
+		$this->context = array( 'source' => 'chip-for-woocommerce' );
 		$this->logger = new WC_Logger();
 	}
 
 	public function log( $message ) {
-		$this->logger->notice( $message, array( 'source' => 'chip-for-woocommerce' ) );
+		try {
+			$this->logger->notice( $message, $this->context );
+		} catch ( Exception $e ) {
+			// Fallback to WordPress error log if WC_Logger fails
+			error_log( 'Chip WooCommerce Logger Error: ' . $e->getMessage() . ' - Message: ' . $message );
+		}
+	}
+
+	public function info( $message ) {
+		try {
+			$this->logger->info( $message, $this->context );
+		} catch ( Exception $e ) {
+			error_log( 'Chip WooCommerce Logger Info: ' . $message );
+		}
+	}
+
+	public function error( $message ) {
+		try {
+			$this->logger->error( $message, $this->context );
+		} catch ( Exception $e ) {
+			error_log( 'Chip WooCommerce Logger Error: ' . $message );
+		}
+	}
+
+	public function debug( $message ) {
+		try {
+			$this->logger->debug( $message, $this->context );
+		} catch ( Exception $e ) {
+			error_log( 'Chip WooCommerce Logger Debug: ' . $message );
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: chipasia, wanzulnet, awisqirani, amirulazreen
 Tags: chip
 Requires at least: 6.3
 Tested up to: 6.8
-Stable tag: 1.7.0
+Stable tag: 1.8.0
 Requires PHP: 7.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -34,11 +34,11 @@ The plugins do includes support for WooCommerce Subscription products.
 
 == Changelog ==
 
-= 1.7.0 2025-07-16 =
-* Removed - Send receipt option from admin settings
-* Changed - Hardcoded send_receipt parameter to false for all payment methods
-* Removed - Unused purchase_sr variable
-
+= 1.8.0 2025-07-18 =
+* Changed - Updated minimum WooCommerce requirement to 9.3.0
+* Changed - Enhanced logger implementation with multiple log levels (info, error, debug)
+* Changed - Improved error handling in logger with fallback to WordPress error_log
+* Changed - Bumped WooCommerce tested version to 10.0
 
 [See changelog for all versions](https://raw.githubusercontent.com/CHIPAsia/chip-for-woocommerce/main/changelog.txt).
 

--- a/readme.txt
+++ b/readme.txt
@@ -35,7 +35,6 @@ The plugins do includes support for WooCommerce Subscription products.
 == Changelog ==
 
 = 1.8.0 2025-07-18 =
-* Changed - Updated minimum WooCommerce requirement to 9.3.0
 * Changed - Enhanced logger implementation with multiple log levels (info, error, debug)
 * Changed - Improved error handling in logger with fallback to WordPress error_log
 * Changed - Bumped WooCommerce tested version to 10.0


### PR DESCRIPTION
## What does this change?
- Fix error with WooCommerce version 9.2.0
- Debug should only available when activated

## Asana / Jira / Trello task link
[Asana](https://app.asana.com/1/1203390264907019/project/1203417845528369/task/1210829829480029?focus=true)

## How to test
- Install on WooCommerce 9.2.0 and make payment
- Install on WooCommerce 10.0 and make payment