### PR TITLE
Fix trunk deploy: read stable tag from SVN source of truth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,17 +66,26 @@ jobs:
       - name: Revert stable tag for trunk deploy
         if: steps.vars.outputs.stage == 'trunk'
         run: |
-          # For trunk testing, keep Stable tag pointing to the previous released
-          # version so users don't auto-update to unreleased code.
-          # In Pattern 2, the latest git tag is always the previous release.
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$PREVIOUS_TAG" ]; then
-            PREVIOUS_STABLE=${PREVIOUS_TAG#v}
-            echo "🧪 Trunk mode: keeping Stable tag at ${PREVIOUS_STABLE}"
-            sed -i "s/^Stable tag: .*/Stable tag: ${PREVIOUS_STABLE}/" dist/chip-for-woocommerce/readme.txt
+          # For trunk testing, keep Stable tag pointing to the version currently
+          # live on WordPress.org (source of truth from SVN trunk readme.txt).
+          svn export --force \
+            --username "${{ secrets.SVN_USERNAME }}" \
+            --password "${{ secrets.SVN_PASSWORD }}" \
+            --non-interactive \
+            "https://plugins.svn.wordpress.org/chip-for-woocommerce/trunk/readme.txt" \
+            /tmp/svn-readme.txt >/dev/null 2>&1 || true
+
+          if [ -f /tmp/svn-readme.txt ]; then
+            CURRENT_STABLE=$(grep -m1 "^Stable tag:" /tmp/svn-readme.txt | awk '{print $3}')
+          fi
+
+          if [ -n "${CURRENT_STABLE:-}" ]; then
+            echo "🧪 Trunk mode: keeping Stable tag at ${CURRENT_STABLE}"
+            sed -i "s/^Stable tag: .*/Stable tag: ${CURRENT_STABLE}/" dist/chip-for-woocommerce/readme.txt
             grep "^Stable tag:" dist/chip-for-woocommerce/readme.txt
+            rm -f /tmp/svn-readme.txt
           else
-            echo "⚠️ No previous tag found; Stable tag left as-is"
+            echo "⚠️ Could not read current stable tag from SVN; leaving as-is"
           fi
 
       - name: Install SVN


### PR DESCRIPTION
## What does this change?
The previous git-tag-based approach was unreliable when the git tag history didn't match the actual WordPress.org state (e.g., after reverting commits, deleting tags, or having multiple test tags).

This PR transitions the source of truth for deployments from Git tags to the SVN trunk. Specifically:
*   **Version Bump**: Updates the plugin version from `2.0.4` to `2.0.5` across `chip-for-woocommerce.php`, `package.json`, and `readme.txt`.
*   **Deployment Workflow Update**: The deployment process now fetches the current `readme.txt` from SVN trunk to read the live Stable tag directly. Release notes are now sourced directly from the internal `changelog.txt` to ensure higher accuracy.
*   **Cleanup**: Removed redundant external scripts and dependencies that were previously required for automated release note generation.

## How to test
1.  **Version Verification**: Check `chip-for-woocommerce.php`, `package.json`, and `readme.txt` to ensure the version strings are consistently set to `2.0.5`.
2.  **Changelog Alignment**: Verify that the content in `changelog.txt` matches the "Changelog" section in `readme.txt`.
3.  **Deployment Simulation**: If possible in a staging environment, verify that the deployment script correctly identifies `2.0.5` as the next stable tag by querying the SVN trunk status rather than relying on local git tags.

## Potential Risks & Review Items
*   **SVN Dependency**: Since the deployment now relies on fetching `readme.txt` from SVN trunk, any connectivity issues with WordPress.org SVN servers during the CI/CD process could stall deployments.
*   **Script Removal**: Ensure that the "Redundant external scripts" removed were not utilized by any other local build processes or developer tooling outside of the release generation.
*   **Version Consistency**: Double-check the constant `CHIP_WOOCOMMERCE_MODULE_VERSION` in the main plugin file to ensure it matches the header version.

## Is this PR safe for automatic approval?
No. Version bumps and changes to the deployment workflow logic should be manually verified to prevent tagging errors on WordPress.org.

## Images
<!-- If applicable, describe visual changes -->

## Related Tasks / PRs
<!-- Provide Asana / Jira / Trello task link here -->

## Checklist
- [ ] Unit tests provided?
- [ ] All tests passing?
- [ ] Tested in staging?
- [ ] Task link provided?
