### PR TITLE
Fix trunk deploy: read stable tag from SVN source of truth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,17 +66,26 @@ jobs:
       - name: Revert stable tag for trunk deploy
         if: steps.vars.outputs.stage == 'trunk'
         run: |
-          # For trunk testing, keep Stable tag pointing to the previous released
-          # version so users don't auto-update to unreleased code.
-          # In Pattern 2, the latest git tag is always the previous release.
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$PREVIOUS_TAG" ]; then
-            PREVIOUS_STABLE=${PREVIOUS_TAG#v}
-            echo "🧪 Trunk mode: keeping Stable tag at ${PREVIOUS_STABLE}"
-            sed -i "s/^Stable tag: .*/Stable tag: ${PREVIOUS_STABLE}/" dist/chip-for-woocommerce/readme.txt
+          # For trunk testing, keep Stable tag pointing to the version currently
+          # live on WordPress.org (source of truth from SVN trunk readme.txt).
+          svn export --force \
+            --username "${{ secrets.SVN_USERNAME }}" \
+            --password "${{ secrets.SVN_PASSWORD }}" \
+            --non-interactive \
+            "https://plugins.svn.wordpress.org/chip-for-woocommerce/trunk/readme.txt" \
+            /tmp/svn-readme.txt >/dev/null 2>&1 || true
+
+          if [ -f /tmp/svn-readme.txt ]; then
+            CURRENT_STABLE=$(grep -m1 "^Stable tag:" /tmp/svn-readme.txt | awk '{print $3}')
+          fi
+
+          if [ -n "${CURRENT_STABLE:-}" ]; then
+            echo "🧪 Trunk mode: keeping Stable tag at ${CURRENT_STABLE}"
+            sed -i "s/^Stable tag: .*/Stable tag: ${CURRENT_STABLE}/" dist/chip-for-woocommerce/readme.txt
             grep "^Stable tag:" dist/chip-for-woocommerce/readme.txt
+            rm -f /tmp/svn-readme.txt
           else
-            echo "⚠️ No previous tag found; Stable tag left as-is"
+            echo "⚠️ Could not read current stable tag from SVN; leaving as-is"
           fi
 
       - name: Install SVN


### PR DESCRIPTION
The previous git-tag-based approach was unreliable when the git tag history didn't match the actual WordPress.org state (e.g. after reverting commits, deleting tags, or having multiple test tags).

Now trunk deploy fetches the current readme.txt from SVN trunk and reads the live Stable tag directly. This is the source of truth for what users currently see on WordPress.org, regardless of local git history.

## What does this change?
This PR updates the deployment workflow and bumps the plugin version to **2.0.5**.

1.  **Release Note Generation:** Replaces the unreliable AI-generated release notes (based on git diffs) with a direct extraction from `changelog.txt`. This ensures GitHub release notes perfectly match the official plugin changelog.
2.  **Workflow Simplification:** Removes Python setup, dependencies, and external AI API calls from the `.github/workflows/deploy.yml` file, reducing build time and complexity.
3.  **Tagging Consistency:** Standardizes GitHub release tags using a `v` prefix (e.g., `v2.0.5`) derived from the workflow's version output.
4.  **Version Bump:** Increments the version from `2.0.4` to `2.0.5` across `chip-for-woocommerce.php`, `package.json`, `readme.txt`, and `changelog.txt`.

## How to test
1.  **Verify Versioning:** Ensure all instances of the version number have been updated to `2.0.5`.
2.  **Verify Changelog Extraction:** The `sed` command in the workflow can be tested locally:
    `sed -n '/^== Changelog ==/{n;:a;p;n;/^$/!ba}' changelog.txt`
    It should return exactly the lines under the `== Changelog ==` header until the first empty line.
3.  **Deployment Run:** (For maintainers) Trigger a release build and confirm that:
    *   The "Extract changelog for release notes" step succeeds.
    *   A GitHub release is created or updated with the name `v2.0.5`.
    *   The release notes contain the text from the 2.0.5 entry in `changelog.txt`.

## Potential Risks & Review Items
*   **Changelog Formatting:** The `sed` logic relies on the `changelog.txt` maintaining its current format (header followed by an immediate entry). If an empty line is inserted before the first entry, the extraction might result in an empty file.
*   **Tagging Convention:** Verify if prepending `v` to the version tag matches the existing repository tagging strategy to avoid duplicate or inconsistent tags.

## Is this PR safe for automatic approval?
No. This PR modifies the deployment pipeline and handles a version release, which requires manual verification to ensure no disruption to the distribution process.

## Images
<!-- If applicable, describe visual changes -->

## Related Tasks / PRs
<!-- Provide Asana / Jira / Trello task link here -->

## Checklist
- [ ] Unit tests provided?
- [ ] All tests passing?
- [ ] Tested in staging?
- [ ] Task link provided?
